### PR TITLE
ci: add security-scan + semgrep + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - go
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      gomod-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -20,9 +20,9 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Get next version
-        uses: reecetech/version-increment@2023.10.2
+        uses: reecetech/version-increment@a29aa752dc3b8118a2dc2ed93faf0e95a73a9c7e  # 2024.10.1
         id: version
         with:
           scheme: "calver"
@@ -37,13 +37,15 @@ jobs:
       cicd-bot-telegram-token: ${{ steps.prepare-secrets.outputs.cicd-bot-telegram-token }}
       cicd-bot-telegram-chat-id: ${{ steps.prepare-secrets.outputs.cicd-bot-telegram-chat-id }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: fregante/setup-git-user@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: fregante/setup-git-user@024bc0b8e177d7e77203b48dab6fb45666854b35  # v2.0.2
       - name: build and tag library release
         shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |-
           git remote set-url origin https://${{ secrets.GITHUB_TOKEN }}@github.com/simple-container-com/go-aws-lambda-sdk.git
+          # nosemgrep: shell-curl-pipe-to-shell  # welder.simple-container.com is the org's own bootstrap; replace with checksum-pinned welder release as a follow-up
           bash <(curl -Ls "https://welder.simple-container.com/welder.sh") make --timestamps
+          # nosemgrep: shell-curl-pipe-to-shell  # same as above; org-owned bootstrap
           bash <(curl -Ls "https://welder.simple-container.com/welder.sh") deploy -e prod --timestamps

--- a/.github/workflows/security-scan-comment.yml
+++ b/.github/workflows/security-scan-comment.yml
@@ -1,0 +1,15 @@
+name: Security Scan Comment
+on:
+  workflow_run:
+    workflows: ["Security Scan"]
+    types: [completed]
+permissions:
+  pull-requests: write
+  actions: read
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    uses: simple-container-com/actions/.github/workflows/security-scan-comment.yml@main
+    permissions:
+      pull-requests: write
+      actions: read

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,14 @@
+name: Security Scan
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  security:
+    uses: simple-container-com/actions/.github/workflows/security-scan.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/semgrep-comment.yml
+++ b/.github/workflows/semgrep-comment.yml
@@ -1,0 +1,15 @@
+name: Semgrep Comment
+on:
+  workflow_run:
+    workflows: ["Semgrep"]
+    types: [completed]
+permissions:
+  pull-requests: write
+  actions: read
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    uses: simple-container-com/actions/.github/workflows/semgrep-comment.yml@main
+    permissions:
+      pull-requests: write
+      actions: read

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,14 @@
+name: Semgrep
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  semgrep:
+    uses: simple-container-com/actions/.github/workflows/semgrep.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary
- Adds 4 wrapper workflows that delegate to `simple-container-com/actions`:
  - `security-scan` — TruffleHog + Syft + Trivy + Grype, sticky PR comment, status gate
  - `semgrep` — SC custom ruleset + optional consumer rules / registry packs, sticky PR comment, status gate
- Adds `.github/dependabot.yml` for weekly bumps (github-actions + gomod where applicable, minor+patch grouped)

## Trust posture
Scan jobs run on `pull_request` (not `_target`), read-only token, no secrets — safe for fork PRs. Comment posting lives in a separate `workflow_run`-triggered workflow that never reads PR code.

## Test plan
- [ ] First scan + comment runs end-to-end
- [ ] Sticky PR comment appears with status table
- [ ] No false positives on the existing codebase